### PR TITLE
webquizzesテーブルの作成とマスターデータの追加

### DIFF
--- a/api/app/models/web_quiz.rb
+++ b/api/app/models/web_quiz.rb
@@ -1,0 +1,2 @@
+class WebQuiz < ApplicationRecord
+end

--- a/api/db/migrate/20230910123411_create_web_quizzes.rb
+++ b/api/db/migrate/20230910123411_create_web_quizzes.rb
@@ -1,0 +1,11 @@
+class CreateWebQuizzes < ActiveRecord::Migration[6.0]
+  def change
+    create_table :web_quizzes do |t|
+      t.string :title
+      t.string :description_ja
+      t.text :typing_content
+
+      t.timestamps
+    end
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -1,0 +1,23 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2023_09_10_123411) do
+
+  create_table "web_quizzes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "title"
+    t.string "description_ja"
+    t.text "typing_content"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+end

--- a/api/db/seeds.rb
+++ b/api/db/seeds.rb
@@ -1,7 +1,49 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+WebQuiz.create!(
+  title: 'APIとは',
+  description_ja: 'アプリケーション間のインターフェースを指し、データ交換を可能にするもの',
+  typing_content: 'apurike-syonnkannoinnta-fe-suwosasi,de-takoukanwokanounisurumono'
+)
+WebQuiz.create!(
+  title: 'migrationとは',
+  description_ja: 'データベースのスキーマ変更を管理するための機能。Railsに組み込まれている',
+  typing_content: 'de-tabe-sunosuki-mahenkouwokannrisurutamenokinou.railsnikumikomareteiru'
+)
+WebQuiz.create!(
+  title: 'MVCとは',
+  description_ja: 'モデル、ビュー、コントローラのアーキテクチャパターン。役割の分離を推進する',
+  typing_content: 'moderu,byu-,kontoro-ranoa-kitekutyapata-nn.yakuwarinobunriwosuishinsuru'
+)
+WebQuiz.create!(
+  title: 'RESTfulとは',
+  description_ja: 'Webサービスの設計原則。リソース指向のアーキテクチャスタイル',
+  typing_content: 'websa-bisunosekkeigensoku.riso-susikounoa-kitekutyasutairu'
+)
+WebQuiz.create!(
+  title: 'CRUDとは',
+  description_ja: 'データ操作の基本。Create,Read,Update,Deleteを指す',
+  typing_content: 'de-tasousanokihon.create,read,update,deletewosasu')
+WebQuiz.create!(
+  title: 'ミドルウェアとは',
+  description_ja: 'リクエストとレスポンスの間で動作するソフトウェア層。機能拡張や処理を追加する',
+  typing_content: 'rikuesutotoresuponsunoaidadedousasurusofutoweasou.kinoukakutyouyasyoriwotuikasuru'
+)
+WebQuiz.create!(
+  title: 'ORMとは',
+  description_ja: 'オブジェクト関係のマッピング。データベースのテーブルとクラスをマッピングする技術',
+  typing_content: 'obujekutokannkeinomappingu.de-tabe-sunote-burutokurasuwomappingusurugijutu'
+)
+WebQuiz.create!(
+  title: 'callbackとは',
+  description_ja: '特定のイベント後に自動的に呼び出される関数やメソッド',
+  typing_content: 'tokuteinoibenntogonijidoutekiniyobidasarerukannsuuyamesoddo'
+)
+WebQuiz.create!(
+  title: 'アセットパイプラインとは',
+  description_ja: '静的アセットの圧縮や結合を行うためのRailsの機能',
+  typing_content: 'seitekiasettonoassyukuyaketugouwookonautamenorailsnokinou'
+)
+WebQuiz.create!(
+  title: 'turbolinksとは',
+  description_ja: 'ページの遷移を高速化するためのRailsのライブラリ。JavaScriptによる動作である',
+  typing_content: 'pe-jinosenniwokousokukasurutamenorailsnoraiburari.javascriptniyorudousadearu'
+)

--- a/api/heroku.yml
+++ b/api/heroku.yml
@@ -1,0 +1,14 @@
+setup:
+  config:
+    RACK_ENV: production
+    RAILS_ENV: production
+    RAILS_LOG_TO_STDOUT: enabled
+    RAILS_SERVE_STATIC_FILES: enabled
+build:
+  docker:
+    web: Dockerfile
+  config:
+    WORKDIR: app
+
+run:
+  web: /bin/sh -c "rm -f tmp/pids/server.pid && bundle exec rails server -b 0.0.0.0 -p $PORT"

--- a/api/test/fixtures/web_quizzes.yml
+++ b/api/test/fixtures/web_quizzes.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  title: MyString
+  description_ja: MyString
+  typing_content: MyText
+
+two:
+  title: MyString
+  description_ja: MyString
+  typing_content: MyText

--- a/api/test/models/web_quiz_test.rb
+++ b/api/test/models/web_quiz_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class WebQuizTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
webquizzesテーブルの作成とマスターデータの追加

## 変更点
web_quizzezテーブルができました

## 影響範囲
なし

## UIの変更
なし

## 今回実装しなかった保留点
「ちゃ」って「cha」とも「tya」とも打てるよね、、
両方打っても変換とかはできそうだけど、その方法難しそうなら
今回はユーザーさんに画面見てもらって、
登録したデータと合っているもの入力してもらおう。。

## 使ったDockerkコマンド
development環境
```
## web_quiizzesのmodelとmigrationファイル追加
 $ docker exec -it typing_rails /bin/bash
 root@19293fca349d:/app# rails generate model create_web_quizzes title:string description_ja:text typing_content:text
 Running via Spring preloader in process 54
       invoke  active_record
       create    db/migrate/20230910115213_create_web_quizzes.rb
 root@19293fca349d:/app# rails db:migrate
 == 20230910115213 CreateWebQuizzes: migrating =================================
 -- create_table(:web_quizzes)
    -> 0.0218s
 == 20230910115213 CreateWebQuizzes: migrated (0.0218s) ========================
 
 root@19293fca349d:/app# exit
 exit
 
## seedデータ投入
 docker exec -it typing_rails /bin/bash
 root@19293fca349d:/app# rails db:seed
```

production環境
```
$ heroku run bash --app web-typing
Running bash on ⬢ web-typing... up, run.4029 (Basic)
~ $ rails db:migrate
== 20230910102104 CreateWebQuizzes: migrating =================================
-- create_table(:web_quizzes)
     -> 0.0248s
== 20230910102104 CreateWebQuizzes: migrated (0.0249s) ========================
~ $ rails db:seed
~ $ exit
exit
```

## 参考記事


## レビュワーに向けて注意点など
